### PR TITLE
Add CRM domain entities with base class inheritance

### DIFF
--- a/src/Crm.Domain/Entities/Activity.cs
+++ b/src/Crm.Domain/Entities/Activity.cs
@@ -1,0 +1,19 @@
+namespace Crm.Domain.Entities
+{
+    using Crm.Domain.Enums;
+
+    public class Activity : BaseEntity
+    {
+        public ActivityType Type { get; set; }
+
+        public RelatedToType RelatedTo { get; set; }
+
+        public Guid? RelatedId { get; set; }
+
+        public DateTime? DueAt { get; set; }
+
+        public ActivityStatus Status { get; set; }
+
+        public string? Notes { get; set; }
+    }
+}

--- a/src/Crm.Domain/Entities/Attachment.cs
+++ b/src/Crm.Domain/Entities/Attachment.cs
@@ -1,0 +1,19 @@
+namespace Crm.Domain.Entities
+{
+    using Crm.Domain.Enums;
+
+    public class Attachment : BaseEntity
+    {
+        public required string FileName { get; set; }
+
+        public long Size { get; set; }
+
+        public string? Url { get; set; }
+
+        public string? BlobRef { get; set; }
+
+        public RelatedToType RelatedTo { get; set; }
+
+        public Guid? RelatedId { get; set; }
+    }
+}

--- a/src/Crm.Domain/Entities/BaseEntity.cs
+++ b/src/Crm.Domain/Entities/BaseEntity.cs
@@ -1,0 +1,7 @@
+namespace Crm.Domain.Entities
+{
+    public abstract class BaseEntity
+    {
+        public Guid Id { get; set; }
+    }
+}

--- a/src/Crm.Domain/Entities/Company.cs
+++ b/src/Crm.Domain/Entities/Company.cs
@@ -1,0 +1,13 @@
+namespace Crm.Domain.Entities
+{
+    public class Company : BaseEntity
+    {
+        public required string Name { get; set; }
+
+        public string? Industry { get; set; }
+
+        public string? Address { get; set; }
+
+        public List<string> Tags { get; set; } = new();
+    }
+}

--- a/src/Crm.Domain/Entities/Contact.cs
+++ b/src/Crm.Domain/Entities/Contact.cs
@@ -1,0 +1,19 @@
+namespace Crm.Domain.Entities
+{
+    public class Contact : BaseEntity
+    {
+        public required string FirstName { get; set; }
+
+        public required string LastName { get; set; }
+
+        public string? Email { get; set; }
+
+        public string? Phone { get; set; }
+
+        public string? Position { get; set; }
+
+        public Guid? CompanyId { get; set; }
+
+        public List<string> Tags { get; set; } = new();
+    }
+}

--- a/src/Crm.Domain/Entities/Deal.cs
+++ b/src/Crm.Domain/Entities/Deal.cs
@@ -1,0 +1,26 @@
+namespace Crm.Domain.Entities
+{
+    using Crm.Domain.Enums;
+    public class Deal : BaseEntity
+    {
+        public required string Title { get; set; }
+
+        public decimal Amount { get; set; }
+
+        public string Currency { get; set; } = "";
+
+        public int Probability { get; set; }
+
+        public Guid StageId { get; set; }
+
+        public Guid? OwnerId { get; set; }
+
+        public Guid? CompanyId { get; set; }
+
+        public Guid? ContactId { get; set; }
+
+        public DateTime? CloseDate { get; set; }
+
+        public DealStatus Status { get; set; } = DealStatus.Open;
+    }
+}

--- a/src/Crm.Domain/Entities/Pipeline.cs
+++ b/src/Crm.Domain/Entities/Pipeline.cs
@@ -1,0 +1,9 @@
+namespace Crm.Domain.Entities
+{
+    public class Pipeline : BaseEntity
+    {
+        public required string Name { get; set; }
+
+        public Guid TenantId { get; set; }
+    }
+}

--- a/src/Crm.Domain/Entities/Stage.cs
+++ b/src/Crm.Domain/Entities/Stage.cs
@@ -1,0 +1,11 @@
+namespace Crm.Domain.Entities
+{
+    public class Stage : BaseEntity
+    {
+        public required string Name { get; set; }
+
+        public int Order { get; set; }
+
+        public Guid PipelineId { get; set; }
+    }
+}

--- a/src/Crm.Domain/Entities/TaskItem.cs
+++ b/src/Crm.Domain/Entities/TaskItem.cs
@@ -1,0 +1,21 @@
+namespace Crm.Domain.Entities
+{
+    using Crm.Domain.Enums;
+
+    public class TaskItem : BaseEntity
+    {
+        public required string Title { get; set; }
+
+        public DateTime? DueAt { get; set; }
+
+        public Guid? OwnerId { get; set; }
+
+        public RelatedToType RelatedTo { get; set; }
+
+        public Guid? RelatedId { get; set; }
+
+        public TaskPriority Priority { get; set; } = TaskPriority.Medium;
+
+        public Crm.Domain.Enums.TaskStatus Status { get; set; } = Crm.Domain.Enums.TaskStatus.Todo;
+    }
+}

--- a/src/Crm.Domain/Entities/Team.cs
+++ b/src/Crm.Domain/Entities/Team.cs
@@ -1,0 +1,7 @@
+namespace Crm.Domain.Entities
+{
+    public class Team : BaseEntity
+    {
+        public required string Name { get; set; }
+    }
+}

--- a/src/Crm.Domain/Entities/Tenant.cs
+++ b/src/Crm.Domain/Entities/Tenant.cs
@@ -1,0 +1,11 @@
+namespace Crm.Domain.Entities
+{
+    public class Tenant : BaseEntity
+    {
+        public required string Name { get; set; }
+
+        public required string Slug { get; set; }
+
+        public string? SettingsJson { get; set; }
+    }
+}

--- a/src/Crm.Domain/Entities/UserTeam.cs
+++ b/src/Crm.Domain/Entities/UserTeam.cs
@@ -1,0 +1,9 @@
+namespace Crm.Domain.Entities
+{
+    public class UserTeam : BaseEntity
+    {
+        public Guid UserId { get; set; }
+
+        public Guid TeamId { get; set; }
+    }
+}


### PR DESCRIPTION
Add CRM domain entities with base class inheritance

This commit introduces a new namespace `Crm.Domain.Entities` and defines multiple entity classes that inherit from `BaseEntity`. The new classes include `Activity`, `Attachment`, `Company`, `Contact`, `Deal`, `Pipeline`, `Stage`, `TaskItem`, `Team`, `Tenant`, and `UserTeam`. Each class features various properties with different data types, including required and optional fields. Additionally, some classes leverage enums from `Crm.Domain.Enums` to represent specific statuses and types relevant to the CRM system.