### PR TITLE
Refactor output caching to use tenant context, not headers

### DIFF
--- a/src/Presentation/Crm.Web/Infrastructure/TenantResolutionMiddleware.cs
+++ b/src/Presentation/Crm.Web/Infrastructure/TenantResolutionMiddleware.cs
@@ -26,9 +26,6 @@ namespace Crm.Web.Infrastructure
             ctx.Items[TenantContextKeys.Context] = tenantContext;
             accessor.Current = tenantContext;
 
-            var cacheKey = tenantContext.TenantSlug;
-            ctx.Request.Headers["X-Tenant"] = cacheKey;
-
             await _next(ctx);
         }
     }

--- a/src/Presentation/Crm.Web/Infrastructure/TenantScopedOutputCachePolicy.cs
+++ b/src/Presentation/Crm.Web/Infrastructure/TenantScopedOutputCachePolicy.cs
@@ -1,0 +1,59 @@
+namespace Crm.Web.Infrastructure
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Crm.Application.Common.Multitenancy;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.OutputCaching;
+
+    public sealed class TenantScopedOutputCachePolicy : IOutputCachePolicy
+    {
+        private readonly TimeSpan _duration;
+        private readonly string[] _varyByQueryKeys;
+
+        public TenantScopedOutputCachePolicy(TimeSpan duration, params string[] varyByQueryKeys)
+        {
+            _duration = duration;
+            _varyByQueryKeys = varyByQueryKeys ?? Array.Empty<string>();
+        }
+
+        public ValueTask CacheRequestAsync(OutputCacheContext context, CancellationToken cancellationToken)
+        {
+            if (!HttpMethods.IsGet(context.HttpContext.Request.Method))
+            {
+                context.EnableOutputCaching = false;
+                return ValueTask.CompletedTask;
+            }
+
+            var accessor = context.HttpContext.RequestServices.GetRequiredService<ITenantContextAccessor>();
+            var tenant = accessor.Current;
+            if (tenant is null)
+            {
+                context.EnableOutputCaching = false;
+                return ValueTask.CompletedTask;
+            }
+
+            context.EnableOutputCaching = true;
+            context.AllowCacheLookup = true;
+            context.AllowCacheStorage = true;
+            context.AllowLocking = true;
+
+            context.ResponseExpirationTimeSpan = _duration;
+            context.CacheVaryByRules.VaryByValues["tenant"] = tenant.TenantSlug;
+
+            if (_varyByQueryKeys.Length > 0)
+            {
+                context.CacheVaryByRules.QueryKeys = _varyByQueryKeys;
+            }
+
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask ServeFromCacheAsync(OutputCacheContext context, CancellationToken cancellationToken)
+            => ValueTask.CompletedTask;
+
+        public ValueTask ServeResponseAsync(OutputCacheContext context, CancellationToken cancellationToken)
+            => ValueTask.CompletedTask;
+    }
+}

--- a/src/Presentation/Crm.Web/Program.cs
+++ b/src/Presentation/Crm.Web/Program.cs
@@ -287,14 +287,17 @@ builder.Services.AddResponseCompression(options =>
 // Output caching for GET endpoints
 builder.Services.AddOutputCache(o =>
 {
-    o.AddPolicy("companies", b => b
-        .Expire(TimeSpan.FromSeconds(30))
-        .SetVaryByQuery("search", "industry", "sort", "asc", "page", "pageSize")
-        .SetVaryByHeader("X-Tenant"));
-    o.AddPolicy("industries", b => b
-        .Expire(TimeSpan.FromMinutes(5))
-        .SetVaryByQuery("search")
-        .SetVaryByHeader("X-Tenant"));
+    o.AddPolicy("companies", new TenantScopedOutputCachePolicy(
+        TimeSpan.FromSeconds(30),
+        "search",
+        "industry",
+        "sort",
+        "asc",
+        "page",
+        "pageSize"));
+    o.AddPolicy("industries", new TenantScopedOutputCachePolicy(
+        TimeSpan.FromMinutes(5),
+        "search"));
 });
 
 // EF-backed services

--- a/tests/Crm.Web.Tests/Multitenancy/TenantOutputCacheTests.cs
+++ b/tests/Crm.Web.Tests/Multitenancy/TenantOutputCacheTests.cs
@@ -146,12 +146,20 @@ namespace Crm.Web.Tests.Multitenancy
             var t1Total = t1Doc.RootElement.GetProperty("total").GetInt32();
             Assert.Equal(1, t1Total);
 
+            var t1Cached = await client.GetAsync("/api/companies?page=1&pageSize=50");
+            Assert.Equal(HttpStatusCode.OK, t1Cached.StatusCode);
+            Assert.True(t1Cached.Headers.Age.HasValue);
+
             await AuthenticateAsync(client, "tenant2.localhost", "admin2@local");
             var t2Res = await client.GetAsync("/api/companies?page=1&pageSize=50");
             Assert.Equal(HttpStatusCode.OK, t2Res.StatusCode);
             using var t2Doc = JsonDocument.Parse(await t2Res.Content.ReadAsStringAsync());
             var t2Total = t2Doc.RootElement.GetProperty("total").GetInt32();
             Assert.Equal(1, t2Total);
+
+            var t2Cached = await client.GetAsync("/api/companies?page=1&pageSize=50");
+            Assert.Equal(HttpStatusCode.OK, t2Cached.StatusCode);
+            Assert.True(t2Cached.Headers.Age.HasValue);
         }
 
         [Fact]


### PR DESCRIPTION
Refactor output caching to use tenant context, not headers

Replaces header-based cache variation with a new TenantScopedOutputCachePolicy that varies cache entries by tenant slug and query keys. Removes the need to set or vary by the "X-Tenant" header in middleware and cache policies. Updates tests to verify tenant-specific cache behavior using the Age header. This improves robustness and simplifies multi-tenant output caching.