### PR TITLE
Safer prod migration workflow, health check improvements

### DIFF
--- a/ops.md
+++ b/ops.md
@@ -4,9 +4,10 @@
 
 ### Recommended production workflow
 
-1. Apply migrations out-of-band:
-   - `dotnet ef database update -p src/Crm.Infrastructure -s src/Presentation/Crm.Web`
-2. Keep `Database:AutoMigrate` set to `false` in production.
+1. Apply migrations out-of-band (recommended):
+  - `dotnet Crm.Web.dll --migrate`
+2. Start the app normally after migrations complete.
+3. Keep `Database:AutoMigrate` set to `false` in production.
 
 ### Auto-migrate behavior
 
@@ -14,10 +15,10 @@
 - Production: auto-migrate is disabled by default. To enable it explicitly, set:
   - `Database:AutoMigrate: true`
 
-If the schema is missing or out of date in production and auto-migrate is disabled, the app fails fast with a clear error and the readiness check will be unhealthy.
+If the schema is missing or out of date in production and auto-migrate is disabled, the app still starts but the readiness check will be unhealthy.
 
-### Optional migration runner mode
+### Migration runner mode
 
-If you want a dedicated run mode, use a startup command or job that only runs:
+Run a one-off migration step during deploy:
 
-- `dotnet ef database update -p src/Crm.Infrastructure -s src/Presentation/Crm.Web`
+- `dotnet Crm.Web.dll --migrate`

--- a/src/Presentation/Crm.Web/appsettings.Production.json
+++ b/src/Presentation/Crm.Web/appsettings.Production.json
@@ -1,0 +1,14 @@
+{
+  "Database": {
+    "AutoMigrate": false
+  },
+  "Seed": {
+    "DemoData": false
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/tests/Crm.Web.Tests/Crm.Web.Tests.csproj
+++ b/tests/Crm.Web.Tests/Crm.Web.Tests.csproj
@@ -14,6 +14,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/tests/Crm.Web.Tests/Health/DbMigrationsHealthCheckTests.cs
+++ b/tests/Crm.Web.Tests/Health/DbMigrationsHealthCheckTests.cs
@@ -1,0 +1,61 @@
+namespace Crm.Web.Tests.Health
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Crm.Application.Common.Multitenancy;
+    using Crm.Infrastructure.Persistence;
+    using Crm.Web.Infrastructure;
+    using Microsoft.Data.Sqlite;
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.Diagnostics.HealthChecks;
+    using Microsoft.Extensions.FileProviders;
+    using Microsoft.Extensions.Hosting;
+
+    public class DbMigrationsHealthCheckTests
+    {
+        private sealed class FixedTenantProvider : ITenantProvider
+        {
+            public Guid TenantId { get; } = Guid.NewGuid();
+        }
+
+        private sealed class TestEnv : IHostEnvironment
+        {
+            public string EnvironmentName { get; set; } = Environments.Production;
+
+            public string ApplicationName { get; set; } = "Crm.Web.Tests";
+
+            public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+
+            public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+        }
+
+        [Fact]
+        public async Task Pending_Migrations_Return_Unhealthy()
+        {
+            await using var conn = new SqliteConnection("DataSource=:memory:");
+            await conn.OpenAsync();
+
+            var options = new DbContextOptionsBuilder<CrmDbContext>()
+                .UseSqlite(conn)
+                .Options;
+
+            await using var db = new CrmDbContext(options, new FixedTenantProvider());
+
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Database:AutoMigrate"] = "false"
+                })
+                .Build();
+
+            var healthCheck = new DbMigrationsHealthCheck(db, new TestEnv(), config);
+            var result = await healthCheck.CheckHealthAsync(new HealthCheckContext(), CancellationToken.None);
+
+            Assert.Equal(HealthStatus.Unhealthy, result.Status);
+            Assert.Contains("Pending migrations", result.Description, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}


### PR DESCRIPTION
Safer prod migration workflow, health check improvements

- Introduce --migrate flag to run DB migrations out-of-band in production, replacing direct EF CLI usage
- Update ops.md to document new migration workflow and clarify readiness health check behavior
- App now starts even if DB schema is missing/outdated (with auto-migrate off), but readiness health check reports unhealthy
- Add logic in Program.cs to handle --migrate flag and exit after migrations
- Switch health endpoints to ASP.NET Core health checks middleware
- Add appsettings.Production.json with safe defaults (auto-migrate and demo data off)
- Add EF Core Sqlite dependency to test project for integration tests
- Add DbMigrationsHealthCheckTests to verify readiness health check behavior with pending migrations