### PR TITLE
Improve attachment storage validation and error handling

### DIFF
--- a/ops.md
+++ b/ops.md
@@ -5,7 +5,9 @@
 ### Recommended production workflow
 
 1. Apply migrations out-of-band (recommended):
-  - `dotnet Crm.Web.dll --migrate`
+
+- `dotnet Crm.Web.dll --migrate`
+
 2. Start the app normally after migrations complete.
 3. Keep `Database:AutoMigrate` set to `false` in production.
 

--- a/src/Crm.Infrastructure/Files/AttachmentStorageException.cs
+++ b/src/Crm.Infrastructure/Files/AttachmentStorageException.cs
@@ -1,0 +1,12 @@
+namespace Crm.Infrastructure.Files
+{
+    public sealed class AttachmentStorageException : InvalidOperationException
+    {
+        public int StatusCode { get; }
+
+        public AttachmentStorageException(string message, int statusCode) : base(message)
+        {
+            StatusCode = statusCode;
+        }
+    }
+}

--- a/src/Crm.Infrastructure/Files/AttachmentStorageOptions.cs
+++ b/src/Crm.Infrastructure/Files/AttachmentStorageOptions.cs
@@ -4,15 +4,22 @@ namespace Crm.Infrastructure.Files
     {
         public string? UploadsRootPath { get; set; }
 
-        public long MaxFileSizeBytes { get; set; } = 10 * 1024 * 1024;
+        public long MaxUploadBytes { get; set; } = 10 * 1024 * 1024;
+
+        // Legacy setting (kept for backward compatibility)
+        public long MaxFileSizeBytes { get; set; }
+
+        public int MaxFileNameLength { get; set; } = 120;
 
         public string[] AllowedContentTypes { get; set; } = new[]
         {
             "application/pdf",
             "image/jpeg",
+            "image/jpg",
             "image/png",
             "image/gif",
             "text/plain",
+            "text/csv",
             "application/msword",
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
             "application/vnd.ms-excel",

--- a/src/Presentation/Crm.Web/appsettings.json
+++ b/src/Presentation/Crm.Web/appsettings.json
@@ -18,13 +18,16 @@
   },
   "Attachments": {
     "UploadsRootPath": "wwwroot/uploads",
-    "MaxFileSizeBytes": 10485760,
+    "MaxUploadBytes": 10485760,
+    "MaxFileNameLength": 120,
     "AllowedContentTypes": [
       "application/pdf",
       "image/jpeg",
+      "image/jpg",
       "image/png",
       "image/gif",
       "text/plain",
+      "text/csv",
       "application/msword",
       "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
       "application/vnd.ms-excel",

--- a/tests/Crm.Web.Tests/Files/AttachmentDownloadTests.cs
+++ b/tests/Crm.Web.Tests/Files/AttachmentDownloadTests.cs
@@ -1,0 +1,179 @@
+namespace Crm.Web.Tests.Files
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Text;
+    using System.Text.RegularExpressions;
+    using Crm.Application.Files;
+    using Crm.Domain.Entities;
+    using Crm.Infrastructure.Files;
+    using Crm.Infrastructure.Persistence;
+    using Microsoft.AspNetCore.Hosting;
+    using Microsoft.AspNetCore.Identity;
+    using Microsoft.AspNetCore.Mvc.Testing;
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.EntityFrameworkCore.Storage;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.DependencyInjection.Extensions;
+
+    public class AttachmentDownloadTests
+    {
+        private sealed class TestWebApplicationFactory : WebApplicationFactory<Program>
+        {
+            public Guid TenantId { get; } = Guid.Parse("11111111-1111-1111-1111-111111111111");
+            private static readonly InMemoryDatabaseRoot DbRoot = new();
+            private readonly string _dbName = $"crm-test-{Guid.NewGuid()}";
+            private readonly string _uploadsRoot = Path.Combine(Path.GetTempPath(), "blazorcrm-tests", Guid.NewGuid().ToString("N"));
+
+            protected override void ConfigureWebHost(IWebHostBuilder builder)
+            {
+                builder.UseEnvironment("Testing");
+
+                builder.ConfigureAppConfiguration(cfg =>
+                {
+                    var settings = new Dictionary<string, string?>
+                    {
+                        ["Tenancy:DefaultTenantSlug"] = "demo",
+                        ["Tenancy:DefaultTenantName"] = "Demo",
+                        ["Tenancy:BaseDomain"] = "crm.yourdomain.com",
+                        ["Tenancy:DevHostSuffix"] = "localhost",
+                        ["Attachments:UploadsRootPath"] = _uploadsRoot,
+                        ["Attachments:MaxUploadBytes"] = "10485760",
+                        ["Attachments:AllowedContentTypes:0"] = "text/plain",
+                        ["Jwt:Key"] = "TEST_KEY_01234567890123456789012345678901",
+                        ["Jwt:Issuer"] = "BlazorCrm",
+                        ["Jwt:Audience"] = "BlazorCrmClients"
+                    };
+
+                    cfg.AddInMemoryCollection(settings);
+                });
+
+                builder.ConfigureServices(services =>
+                {
+                    services.RemoveAll<DbContextOptions<CrmDbContext>>();
+                    services.AddDbContext<CrmDbContext>(o => o.UseInMemoryDatabase(_dbName, DbRoot));
+                });
+            }
+        }
+
+        private static async Task SeedAsync(IServiceProvider services, Guid tenantId)
+        {
+            using var scope = services.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<CrmDbContext>();
+            await db.Database.EnsureCreatedAsync();
+
+            if (!await db.Tenants.AnyAsync(t => t.Id == tenantId))
+            {
+                db.Tenants.Add(new Tenant { Id = tenantId, Name = "Demo", Slug = "demo" });
+                await db.SaveChangesAsync();
+            }
+
+            var userManager = scope.ServiceProvider.GetRequiredService<UserManager<IdentityUser>>();
+            var user = await userManager.FindByEmailAsync("admin@local");
+            if (user is null)
+            {
+                user = new IdentityUser { UserName = "admin@local", Email = "admin@local", EmailConfirmed = true };
+                await userManager.CreateAsync(user, "Admin123$");
+            }
+
+            var claims = await userManager.GetClaimsAsync(user);
+            if (!claims.Any(c => c.Type == "tenant" && c.Value == tenantId.ToString()))
+            {
+                await userManager.AddClaimAsync(user, new System.Security.Claims.Claim("tenant", tenantId.ToString()));
+            }
+
+            if (!claims.Any(c => c.Type == "tenant_slug" && c.Value == "demo"))
+            {
+                await userManager.AddClaimAsync(user, new System.Security.Claims.Claim("tenant_slug", "demo"));
+            }
+        }
+
+        private static async Task<string> GetAntiforgeryTokenAsync(HttpClient client)
+        {
+            var res = await client.GetAsync("/login");
+            res.EnsureSuccessStatusCode();
+
+            var html = await res.Content.ReadAsStringAsync();
+            var match = Regex.Match(html, "name=\"__RequestVerificationToken\"[^>]*value=\"([^\"]+)\"", RegexOptions.IgnoreCase);
+            if (!match.Success)
+            {
+                throw new InvalidOperationException("Antiforgery token was not found in the login page.");
+            }
+
+            return match.Groups[1].Value;
+        }
+
+        private static async Task<HttpClient> SignInAsync(TestWebApplicationFactory factory)
+        {
+            var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+            {
+                AllowAutoRedirect = false,
+                HandleCookies = true
+            });
+            client.DefaultRequestHeaders.Host = "demo.localhost";
+
+            var token = await GetAntiforgeryTokenAsync(client);
+            var form = new Dictionary<string, string>
+            {
+                ["__RequestVerificationToken"] = token,
+                ["Email"] = "admin@local",
+                ["Password"] = "Admin123$"
+            };
+
+            var login = await client.PostAsync("/auth/login", new FormUrlEncodedContent(form));
+            Assert.Equal(HttpStatusCode.Redirect, login.StatusCode);
+
+            return client;
+        }
+
+        [Fact]
+        public async Task Download_Returns_ContentType_And_FileName()
+        {
+            var factory = new TestWebApplicationFactory();
+            await SeedAsync(factory.Services, factory.TenantId);
+
+            Guid attachmentId;
+            await using (var scope = factory.Services.CreateAsyncScope())
+            {
+                var db = scope.ServiceProvider.GetRequiredService<CrmDbContext>();
+                var storage = scope.ServiceProvider.GetRequiredService<IFileStorage>();
+                await using var content = new MemoryStream(Encoding.UTF8.GetBytes("hello"));
+
+                var blobRef = await storage.SaveAsync(content, "Report 2026.txt", "text/plain", factory.TenantId, "demo", CancellationToken.None);
+
+                var attachment = new Attachment
+                {
+                    Id = Guid.NewGuid(),
+                    TenantId = factory.TenantId,
+                    FileName = "Report 2026.txt",
+                    ContentType = "text/plain",
+                    BlobRef = blobRef,
+                    RelatedTo = Crm.Domain.Enums.RelatedToType.Deal,
+                    RelatedId = Guid.NewGuid()
+                };
+
+                await db.Attachments.AddAsync(attachment);
+                await db.SaveChangesAsync();
+                attachmentId = attachment.Id;
+            }
+
+            var client = await SignInAsync(factory);
+            var res = await client.GetAsync($"/attachments/{attachmentId}");
+
+            Assert.Equal(HttpStatusCode.OK, res.StatusCode);
+            Assert.Equal("text/plain", res.Content.Headers.ContentType?.MediaType);
+
+            var contentDisposition = res.Content.Headers.ContentDisposition?.ToString();
+            if (string.IsNullOrWhiteSpace(contentDisposition) && res.Content.Headers.TryGetValues("Content-Disposition", out var values))
+            {
+                contentDisposition = values.FirstOrDefault();
+            }
+
+            contentDisposition ??= string.Empty;
+
+            Assert.Contains("Report 2026.txt", contentDisposition);
+        }
+    }
+}


### PR DESCRIPTION
Improve attachment storage validation and error handling

- Add AttachmentStorageException for precise HTTP error codes (400, 413, 415) in file storage operations
- Refactor AttachmentStorageOptions: introduce MaxUploadBytes, MaxFileNameLength, and expand allowed content types
- Enforce file name length and stricter path traversal checks in LocalFileStorage
- Normalize blob references in EfAttachmentService for safety
- Update global exception handler and download endpoint to use new error handling and file name logic
- Update appsettings.json for new options and content types
- Add and update tests for error cases and download behavior
- Clarify documentation on migration workflow